### PR TITLE
recover page links in WritingObjects page

### DIFF
--- a/_guides/1.GuideToWritingObjects.md
+++ b/_guides/1.GuideToWritingObjects.md
@@ -11,12 +11,12 @@ Example code is distributed as a part of the [Min-DevKit Package](https://github
 
 See Also:
 
-* [Guide To Theading](GuideToThreading.md)
-* [Guide To Audio](GuideToAudio.md)
-* [Guide To Initialization](GuideToInitialization.md)
-* [Guide To UI Objects](GuideToUserInterfaceObjects.md)
-* [Special Messages](SpecialMethods.md)
-* [Where To Look...](WhereToLook.md)
+* [Guide To Theading]({{ site.github.url }}{% link _guides/GuideToThreading.md %})
+* [Guide To Audio]({{ site.github.url }}{% link _guides/GuideToAudio.md %})
+* [Guide To Initialization]({{ site.github.url }}{% link _guides/GuideToInitialization.md %})
+* [Guide To UI Objects]({{site.github.url }}{% link _guides/GuideToUserInterfaceObjects.md %})
+* [Special Messages]({{ site.github.url }}{% link _guides/GuideToSpecialMethods.md %})
+* [Where To Look...]({{ site.github.url }}{% link _guides/GuideToWhereToLook.md %})
 
 
 ## Includes


### PR DESCRIPTION
This is my first pull request in min-devkit.

I found missing links in http://cycling74.github.io/min-devkit/guide/writingobjects , so it is easy for me to fix there, I send a this pull request.

I tried to fix there using [`site.github.url` variable](https://help.github.com/en/articles/repository-metadata-on-github-pages#available-repository-metadata) and [link tag filters](https://jekyllrb.com/docs/liquid/tags/#links).

They are useful to generate local links. Link tag filter output errors when find some missing links. 
`site.github.url` provides repository custom url.