### PR TITLE
Restructure GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Release
 
 on: [push, pull_request]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: Release
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
 
 jobs:
   package:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,6 @@ jobs:
         submodules: 'recursive'
         fetch-depth: '0'
 
-    - uses: maxim-lobanov/setup-xcode@v1
-      if: matrix.os == 'macos-latest'
-      with:
-        xcode-version: '11.7'
-              
     - uses: benjlevesque/short-sha@v1.2
       id: short-sha
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Test
+
+on:
+  push:
+    branches: 
+      - master
+      - develop
+  pull_request:
+    branches: 
+      - master
+      - develop
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Build and test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+        fetch-depth: '0'
+
+    - name: Configure macOS
+      if: matrix.os == 'macos-latest'
+      run: mkdir build && cd build && cmake -G Xcode ..
+ 
+    - name: Configure Windows
+      if: matrix.os == 'windows-latest'
+      run: mkdir build && cd build && cmake ..
+
+    - name: Build Debug
+      run: cmake --build build --config 'Debug'
+
+    - name: Test Debug
+      run: cd build && ctest -C 'Debug' . -V
+
+    - name: Build Release
+      run: cmake --build build --config 'Release'
+
+    - name: Test Release
+      run: cd build && ctest -C 'Release' . -V


### PR DESCRIPTION
This PR makes some changes to reduce the number of CI minutes spent for every commit.

**Release workflow**
The existing CI workflow is renamed to Release and only runs when manually triggered. Previously, this workflow ran for every push and pull request on all branches.

**Test workflow**
The test workflow builds and runs the tests with debug and release configurations on macOS and Windows. Instead of running the debug and release configurations in parallel (like what the release workflow does), we run the builds in sequence. This saves an additional checkout and CMake project generation, and also ensures that the release build does not run if the more strict debug build fails.

The test workflow runs automatically on every push to master or develop, as well as every PR that wants to merge to one of these branches.

And finally, the latest Xcode is now used to build on macOS.