### PR TITLE
remove git submodule update from cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,6 @@ if (${CMAKE_GENERATOR} MATCHES "Xcode")
 endif ()
 
 
-# Fetch the correct version of the min-api
-message(STATUS "Updating Git Submodules")
-execute_process(
-    COMMAND				git submodule update --init --recursive
-    WORKING_DIRECTORY	"${CMAKE_CURRENT_SOURCE_DIR}"
-)
-
-
 # Misc setup and subroutines
 include(${CMAKE_CURRENT_SOURCE_DIR}/source/min-api/script/min-package.cmake)
 


### PR DESCRIPTION
see https://github.com/Cycling74/min-devkit/pull/186 for motivation and https://github.com/Cycling74/min-devkit/issues/185 why keeping the `git submodule` command can be problematic.