### PR TITLE
CMake build system refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,20 @@
 cmake_minimum_required(VERSION 3.19)
 project(Min-DevKit)
 
+
+option(C74_BUILD_PROVIDED_PROJECTS "Build the provided projects" ON)
+option(C74_SORT_INTO_FOLDERS "Sort projects and targets into folders (in the IDE)" OFF)
+option(C74_SURPRESS_AUTOMATIC_CMAKE_REGENERATION "Prevent IDE automatically running CMake when a file has changed" ON)
+
+set(C74_MINDEVKIT_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+set(C74_DEFAULT_PROJECT_CXX_STANDARD 17) # all projects added with c74_add_project() are set to this C++ version by default. 
+
+set_property(GLOBAL PROPERTY USE_FOLDERS ${C74_SORT_INTO_FOLDERS})
+set(CMAKE_SUPPRESS_REGENERATION ${C74_AUTOMATIC_CMAKE_REGENERATION})
+
+
+include(script/c74_add_project.cmake)
+
 enable_testing()
 
 string(REGEX REPLACE "(.*)/" "" THIS_PACKAGE_NAME "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -30,20 +44,27 @@ endif()
 include(${CMAKE_CURRENT_SOURCE_DIR}/source/min-api/script/min-package.cmake)
 
 
-# Add the Lib, if it exists
+# Add the min-api, if it exists
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/source/min-api/CMakeLists.txt")
+    add_subdirectory(source/min-api)
+else()
+    message(FATAL_ERROR "The min-api repository is missing. Maybe you did not clone recursively?")
+endif ()
+# Add the min-lib, if it exists
 if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/source/min-lib/CMakeLists.txt")
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/source/min-lib)
+else()
+    message(FATAL_ERROR "The min-lib repository is missing. Maybe you did not clone recursively?")
 endif ()
 
-
-# Generate a project for every folder in the "source/projects" folder
-SUBDIRLIST(PROJECT_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/source/projects)
-foreach (project_dir ${PROJECT_DIRS})
-    if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/source/projects/${project_dir}/CMakeLists.txt")
-        message("Generating: ${project_dir}")
-        add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/source/projects/${project_dir})
-    endif ()
-endforeach ()
-
-# Comment the line below if you want automatic cmake regneration enabled
-set(CMAKE_SUPPRESS_REGENERATION true)
+if (C74_BUILD_PROVIDED_PROJECTS)
+    # Generate a project for every folder in the "source/projects" folder
+    SUBDIRLIST(PROJECT_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/source/projects)
+    foreach (project_dir ${PROJECT_DIRS})
+            if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/source/projects/${project_dir}/CMakeLists.txt")
+                message("Generating: ${project_dir}")
+                add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/source/projects/${project_dir})
+                set_target_properties(${project_dir} PROPERTIES FOLDER "Projects")
+            endif ()
+    endforeach ()
+endif ()

--- a/script/c74_add_project.cmake
+++ b/script/c74_add_project.cmake
@@ -1,0 +1,33 @@
+# Copyright 2018 The Max-API Authors. All rights reserved.
+# Use of this source code is governed by the MIT License found in the License.md file.
+
+
+# Add a new max external project with given target name. A project and a target with 
+# this name is created and prepared to use with the min-devkit. The target is automatically 
+# linked against the necessary libraries. 
+#
+# Call example: 
+# c74_add_project(mytarget SOURCES main.cpp asd.cpp)
+
+function(c74_add_project target)
+	set(multiValueArgs SOURCES)
+	cmake_parse_arguments(PARSE_ARGV 0 PARAMS "${options}" "${oneValueArgs}" "${multiValueArgs}")
+	
+
+	if (DEFINED C74_LIBRARY_OUTPUT_DIRECTORY)
+		set(OUTPUT_DIRECTORY "${C74_LIBRARY_OUTPUT_DIRECTORY}")
+	else()
+		if (NOT DEFINED C74_BUILD_MAX_EXTENSION)
+			set(OUTPUT_DIRECTORY "${C74_MINDEVKIT_PATH}/externals")
+		else ()
+			set(OUTPUT_DIRECTORY "${C74_MINDEVKIT_PATH}/extensions")
+		endif ()
+	endif()
+		
+
+	add_definitions(-DC74_USE_MIN_LIB)
+	c74_add_min_target(${target} SOURCES ${PARAMS_SOURCES} OUTPUT_DIRECTORY ${OUTPUT_DIRECTORY}) # no quotes!
+
+	set_target_properties(${target} PROPERTIES FOLDER "Projects")
+
+endfunction()


### PR DESCRIPTION
Changes

- Add some CMake options
  - Option for enabling IDE folders which sorts all projects into folders (default off to make it as it originally was). All libraries are put in a "C74_Libraries" folder, externals in a "Projects" folder and unit tests in a "Unit Tests" folder. 
  - Option for building example projects (default on). 
  - Option for surpressings automatic cmake regeneration (default on because this was set originally). 
- added `c74_add_project.cmake` file with command `c74_add_project()` to replace includes of the pre and post scripts. The library output directories are set here instead of in the `max-pretarget.cmake` which makes more sense because the path lies in the min-devkit folder, not in the max-sdk-base.
- add `min-api` as subdirectory to bring all targets and functions into scope. `min-api` can still be a totally independant repository. The change here is that the option `BUILD_DOCUMENTATION` is available. Suggestion: we could add a `if(PROJECT_IS_TOP_LEVEL)` in the `CMakeLists.txt` file of `min-api` to only supply that option when `min-api` is built on its own. 
